### PR TITLE
fix: fix out-of-bounds error

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.3.0
+version: 2.3.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics

--- a/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
+++ b/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
@@ -90,17 +90,27 @@ public class TitaniumCrashlyticsModule extends KrollModule
 				fileName = splitByParen[1];
 				lineNumber = 0;
 			}
-						
-			String declaringClass = splitByParen[0].substring(0, splitByParen[0].lastIndexOf('.')).trim();
-			String methodName = splitByParen[0].substring(splitByParen[0].lastIndexOf('.') + 1);
-			
-			if (declaringClass == null) {
+
+			int lastIndex = splitByParen[0].lastIndexOf('.');
+
+			String declaringClass = "";
+			String methodName = "";
+
+			if (lastIndex == -1) {
 				declaringClass = "unknown";
-			}
-			if (methodName == null) {
 				methodName = "unknown";
-			}
+			} else {
+				declaringClass = splitByParen[0].substring(0, lastIndex).trim();
+				methodName = splitByParen[0].substring(lastIndex + 1);
 				
+				if (declaringClass == null) {
+					declaringClass = "unknown";
+				}
+				if (methodName == null) {
+					methodName = "unknown";
+				}
+			}
+
 			trace[i+1] = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
 	    }
 			


### PR DESCRIPTION
This should fix the following error for rare cases:
```zsh
ti:/kroll.js.Uncaught Error: String index out of range: -1 ( handled = this._fireSyncEventToParent(type, data);:1647)
java.lang.String.substring (String.java:2064)
ti.crashlytics.TitaniumCrashlyticsModule.generateStackTrace (TitaniumCrashlyticsModule.java:94)
ti.crashlytics.TitaniumCrashlyticsModule$1.handleException (TitaniumCrashlyticsModule.java:117)
```