### PR TITLE
feat: add recordError() method for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,10 @@ Log a Custom Event to see user actions that are uniquely important for your app 
 ### `setUserIdentifier(userIdentifier)`
 
 Specify a user identifier which will be visible in the Crashlytics UI.
-### iOS only API's
 
 ### `recordError({ domain, code, userInfo })`
 
-Records non-fatal errors.
+Records non-fatal errors. Note: The `code` and `userInfo` parameters are iOS-only.
 
 ### Android only API's
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Log a Custom Event to see user actions that are uniquely important for your app 
 ### `setUserIdentifier(userIdentifier)`
 
 Specify a user identifier which will be visible in the Crashlytics UI.
+### iOS only API's
+
+### `recordError({ domain, code, userInfo })`
+
+Records non-fatal errors.
 
 ### Android only API's
 

--- a/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
+++ b/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
@@ -8,6 +8,7 @@
  */
 package ti.crashlytics;
 
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.KrollRuntime;
@@ -68,6 +69,12 @@ public class TitaniumCrashlyticsModule extends KrollModule
 	@Kroll.method
 	public void trackCustomValue(String key, String userProperty) {
 		FirebaseCrashlytics.getInstance().setCustomKey(key, userProperty);
+	}
+
+	@Kroll.method
+	public void recordError(KrollDict params) {
+		String domain = params.getString("domain");
+		FirebaseCrashlytics.getInstance().recordException(new Throwable(domain));
 	}
 
 	public static StackTraceElement[] generateStackTrace(String javaStack, String jsStack, String errorSourceName, String errorMessage, String errorLineSource, int errorLine) {

--- a/example/app.js
+++ b/example/app.js
@@ -19,5 +19,18 @@ btn.addEventListener('click', () => {
   Crashlytics.crash();
 });
 
+// Use recordError() to logs non-fatal (JS) errors in iOS:
+Ti.App.addEventListener("uncaughtException", function(e) {
+  // Log some logs, for example full error info:
+  FirebaseCrashlytics.log(JSON.stringify(e));
+
+  FirebaseCrashlytics.recordError({
+    domain: e.message, // Domain + code used to group similar errors in dashboard
+    code: 1,
+    // Put additional info here
+    userInfo: {}
+  });
+});
+
 win.add(btn);
 win.open();

--- a/ios/Classes/TiCrashlyticsModule.m
+++ b/ios/Classes/TiCrashlyticsModule.m
@@ -42,6 +42,16 @@
   [[FIRCrashlytics crashlytics] logWithFormat:@"%@", value];
 }
 
+- (void)recordError:(id)args
+{
+  ENSURE_SINGLE_ARG(args, NSDictionary)
+  NSString *errorDomain = [TiUtils stringValue:@"domain" properties:args];
+  NSInteger errorCode = [TiUtils intValue:@"code" properties:args def:0];
+  NSDictionary *userInfo = [args objectForKey:@"userInfo"];
+  NSError *error = [NSError errorWithDomain:errorDomain code:errorCode userInfo: userInfo];
+  [[FIRCrashlytics crashlytics] recordError:error];
+}
+
 - (void)crash:(id)unused
 {
   assert(NO); // Forces a crash


### PR DESCRIPTION
Useful for logging non-fatal (JS-runtime) errors for iOS.