### PR TITLE
fix(android): split length

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.5.0
+version: 2.5.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics

--- a/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
+++ b/android/src/ti/crashlytics/TitaniumCrashlyticsModule.java
@@ -101,23 +101,25 @@ public class TitaniumCrashlyticsModule extends KrollModule
 
 			String fileName = "";
 			int lineNumber = 0;
-			if (splitByParen[1].indexOf(":") > -1) {
-				String[] insideParen = splitByParen[1].split(":");
-				for (int j = 0; j < insideParen.length; j++) {
-					if ((insideParen[j].matches("[0-9]+"))) {
-				        // within the parenthesis, the first number is the line number, for both javaStack and jsStack
-				        lineNumber = Integer.parseInt(insideParen[j]);
-				        break;
-					} else {
-				        // within the parenthesis, everything before first number is the fileName
-				        fileName += insideParen[j] + ":";
-				    }
+			if (splitByParen.length > 1) {
+				if (splitByParen[1].indexOf(":") > -1) {
+					String[] insideParen = splitByParen[1].split(":");
+					for (int j = 0; j < insideParen.length; j++) {
+						if ((insideParen[j].matches("[0-9]+"))) {
+							// within the parenthesis, the first number is the line number, for both javaStack and jsStack
+							lineNumber = Integer.parseInt(insideParen[j]);
+							break;
+						} else {
+							// within the parenthesis, everything before first number is the fileName
+							fileName += insideParen[j] + ":";
+						}
+					}
+					// remove extra ":"
+					fileName = fileName.substring(0, fileName.length() - 1);
+				} else {
+					fileName = splitByParen[1];
+					lineNumber = 0;
 				}
-				// remove extra ":"
-				fileName = fileName.substring(0, fileName.length() - 1);
-			} else {
-				fileName = splitByParen[1];
-				lineNumber = 0;
 			}
 
 			int lastIndex = splitByParen[0].lastIndexOf('.');


### PR DESCRIPTION
We assume `splitByParen` has always 2 elements. If it doesn't it will fail accessing `splitByParen[1]`. Adding a `if (splitByParen.length > 1) {` check around it.

[ti.crashlytics-android-2.5.1.zip](https://github.com/hansemannn/titanium-crashlytics/files/9607869/ti.crashlytics-android-2.5.1.zip)
