### PR TITLE
Android: update to 18.3.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	implementation 'com.google.firebase:firebase-analytics:21.1.1'
-	implementation 'com.google.firebase:firebase-crashlytics:18.2.13'
+	implementation 'com.google.firebase:firebase-crashlytics:18.3.2'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.5.3
+version: 2.5.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics


### PR DESCRIPTION
Changelog:
* 18.3.0: Improved crash reporting reliability for crashes that occur early in the app's lifecycle.
* 18.3.1: Fixed an https://github.com/firebase/firebase-android-sdk/issues/4223 in v18.3.0 that caused a NoClassDefFoundError in specific cases.
* 18.3.2 only fixed a NDK issue

[ti.crashlytics-android-2.5.4.zip](https://github.com/hansemannn/titanium-crashlytics/files/10236916/ti.crashlytics-android-2.5.4.zip)


App builds fine (Ti 12.0.0), test crash appears in the firebase console