### PR TITLE
Android: update library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	implementation 'com.google.firebase:firebase-analytics:21.1.1'
-	implementation 'com.google.firebase:firebase-crashlytics:18.3.2'
+	implementation 'com.google.firebase:firebase-analytics:21.3.0'
+	implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.5.4
+version: 2.5.5
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics


### PR DESCRIPTION
Update library versions

Crashes still visible in the backend:
![Screenshot_20230622_140819](https://github.com/hansemannn/titanium-crashlytics/assets/4334997/8d7eed10-71e2-465f-89a9-1b1e855a1a03)

[ti.crashlytics-android-2.5.5.zip](https://github.com/hansemannn/titanium-crashlytics/files/11833749/ti.crashlytics-android-2.5.5.zip)
