### PR TITLE
android: update to 18.6.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	implementation 'com.google.firebase:firebase-analytics:21.3.0'
-	implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
+	implementation 'com.google.firebase:firebase-analytics:21.5.1'
+	implementation 'com.google.firebase:firebase-crashlytics:18.6.2'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.5.5
+version: 2.6.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics


### PR DESCRIPTION
[ti.crashlytics-android-2.6.0.zip](https://github.com/hansemannn/titanium-crashlytics/files/14423869/ti.crashlytics-android-2.6.0.zip)

Crashlytics data is showing up and the new "Release monitor" too:


![Screenshot_20240227_193146](https://github.com/hansemannn/titanium-crashlytics/assets/4334997/24ed1ba1-1950-4fcb-99ee-d9495a22ff2b)
