### PR TITLE
chore(android): update analytics to 22.2.0 and crashlytics to 19.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	implementation 'com.google.firebase:firebase-analytics:21.3.0'
-	implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
+	implementation 'com.google.firebase:firebase-analytics:22.2.0'
+	implementation 'com.google.firebase:firebase-crashlytics:19.4.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.5.5
+version: 3.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics
@@ -15,4 +15,4 @@ name: titanium-crashlytics
 moduleid: ti.crashlytics
 guid: 108ab55a-0cbb-4c63-ade2-536dabdfa250
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0

--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: titanium-crashlytics
 moduleid: ti.crashlytics
 guid: 108ab55a-0cbb-4c63-ade2-536dabdfa250
 platform: android
-minsdk: 12.7.0
+minsdk: 9.0.0


### PR DESCRIPTION
Latest Firebase library versions bring many improvements and bug fixes in terms of how the background processing is done internally. We should start using the latest versions for more stability.

[Firebase Crashlytics Release Notes for all changes.](https://firebase.google.com/support/release-notes/android)

[Crashlytics Version 19.2.0 improved background handling.](https://firebase.google.com/support/release-notes/android#crashlytics_v19-2-0)

Bumped the major version as it requires `compileSdkVersion: 34`.

[ti.crashlytics-android-3.0.0.zip](https://github.com/user-attachments/files/18850912/ti.crashlytics-android-3.0.0.zip)
