### PR TITLE
fix(android): compiled with SDK 12.5.1.GA as 12.6.x breaks build process

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-crashlytics


### PR DESCRIPTION
[ti.crashlytics-android-3.0.1.zip](https://github.com/user-attachments/files/19104884/ti.crashlytics-android-3.0.1.zip)
